### PR TITLE
correct warning

### DIFF
--- a/src/CSCartApi.php
+++ b/src/CSCartApi.php
@@ -139,7 +139,7 @@ class CSCartApi {
         }
     }
     
-    public function get($objectUrl, $params){
+    public function get($objectUrl, $params = array()){
         return $this->makeRequest($objectUrl, 'GET', '', $params);
     }
 


### PR DESCRIPTION
We do not always pass parameters to the get function